### PR TITLE
Legger til nye, åpne topics for brukernotifikasjoner.

### DIFF
--- a/.github/workflows/on-push-to-main-beskjed-dev-gcp.yaml
+++ b/.github/workflows/on-push-to-main-beskjed-dev-gcp.yaml
@@ -1,0 +1,25 @@
+name: Deploy beskjed-topic i dev-gcp
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - dev-gcp/aapen-brukernotifikasjon-beskjed.yaml
+
+jobs:
+  build-and-publish-on-master:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Sjekk ut koden
+        uses: actions/checkout@v2
+
+      - name: 'Deploy-er til min-side i dev-gcp'
+        uses: 'nais/deploy/actions/deploy@v1'
+        env:
+          REF: ${{ github.sha }}
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: dev-gcp
+          RESOURCE: ./dev-gcp/aapen-brukernotifikasjon-beskjed.yaml
+          PRINT_PAYLOAD: true

--- a/.github/workflows/on-push-to-main-beskjed-prod-gcp.yaml
+++ b/.github/workflows/on-push-to-main-beskjed-prod-gcp.yaml
@@ -1,0 +1,25 @@
+name: Deploy beskjed-topic i prod-gcp
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - prod-gcp/aapen-brukernotifikasjon-beskjed.yaml
+
+jobs:
+  build-and-publish-on-master:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Sjekk ut koden
+        uses: actions/checkout@v2
+
+      - name: 'Deploy-er til min-side i prod-gcp'
+        uses: 'nais/deploy/actions/deploy@v1'
+        env:
+          REF: ${{ github.sha }}
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: prod-gcp
+          RESOURCE: ./prod-gcp/aapen-brukernotifikasjon-beskjed.yaml
+          PRINT_PAYLOAD: true

--- a/.github/workflows/on-push-to-main-done-dev-gcp.yaml
+++ b/.github/workflows/on-push-to-main-done-dev-gcp.yaml
@@ -1,0 +1,25 @@
+name: Deploy done-topic i dev-gcp
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - dev-gcp/aapen-brukernotifikasjon-done.yaml
+
+jobs:
+  build-and-publish-on-master:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Sjekk ut koden
+        uses: actions/checkout@v2
+
+      - name: 'Deploy-er til min-side i dev-gcp'
+        uses: 'nais/deploy/actions/deploy@v1'
+        env:
+          REF: ${{ github.sha }}
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: dev-gcp
+          RESOURCE: ./dev-gcp/aapen-brukernotifikasjon-done.yaml
+          PRINT_PAYLOAD: true

--- a/.github/workflows/on-push-to-main-done-prod-gcp.yaml
+++ b/.github/workflows/on-push-to-main-done-prod-gcp.yaml
@@ -1,0 +1,25 @@
+name: Deploy done-topic i prod-gcp
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - prod-gcp/aapen-brukernotifikasjon-done.yaml
+
+jobs:
+  build-and-publish-on-master:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Sjekk ut koden
+        uses: actions/checkout@v2
+
+      - name: 'Deploy-er til min-side i prod-gcp'
+        uses: 'nais/deploy/actions/deploy@v1'
+        env:
+          REF: ${{ github.sha }}
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: prod-gcp
+          RESOURCE: ./prod-gcp/aapen-brukernotifikasjon-done.yaml
+          PRINT_PAYLOAD: true

--- a/.github/workflows/on-push-to-main-feilrespons-dev-gcp.yaml
+++ b/.github/workflows/on-push-to-main-feilrespons-dev-gcp.yaml
@@ -1,0 +1,25 @@
+name: Deploy feilrespons-topic i dev-gcp
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - dev-gcp/aapen-brukernotifikasjon-feilrespons.yaml
+
+jobs:
+  build-and-publish-on-master:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Sjekk ut koden
+        uses: actions/checkout@v2
+
+      - name: 'Deploy-er til min-side i dev-gcp'
+        uses: 'nais/deploy/actions/deploy@v1'
+        env:
+          REF: ${{ github.sha }}
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: dev-gcp
+          RESOURCE: ./dev-gcp/aapen-brukernotifikasjon-feilrespons.yaml
+          PRINT_PAYLOAD: true

--- a/.github/workflows/on-push-to-main-feilrespons-prod-gcp.yaml
+++ b/.github/workflows/on-push-to-main-feilrespons-prod-gcp.yaml
@@ -1,0 +1,25 @@
+name: Deploy feilrespons-topic i prod-gcp
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - prod-gcp/aapen-brukernotifikasjon-feilrespons.yaml
+
+jobs:
+  build-and-publish-on-master:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Sjekk ut koden
+        uses: actions/checkout@v2
+
+      - name: 'Deploy-er til min-side i prod-gcp'
+        uses: 'nais/deploy/actions/deploy@v1'
+        env:
+          REF: ${{ github.sha }}
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: prod-gcp
+          RESOURCE: ./prod-gcp/aapen-brukernotifikasjon-feilrespons.yaml
+          PRINT_PAYLOAD: true

--- a/.github/workflows/on-push-to-main-innboks-dev-gcp.yaml
+++ b/.github/workflows/on-push-to-main-innboks-dev-gcp.yaml
@@ -1,0 +1,25 @@
+name: Deploy innboks-topic i dev-gcp
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - dev-gcp/aapen-brukernotifikasjon-innboks.yaml
+
+jobs:
+  build-and-publish-on-master:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Sjekk ut koden
+        uses: actions/checkout@v2
+
+      - name: 'Deploy-er til min-side i dev-gcp'
+        uses: 'nais/deploy/actions/deploy@v1'
+        env:
+          REF: ${{ github.sha }}
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: dev-gcp
+          RESOURCE: ./dev-gcp/aapen-brukernotifikasjon-innboks.yaml
+          PRINT_PAYLOAD: true

--- a/.github/workflows/on-push-to-main-innboks-prod-gcp.yaml
+++ b/.github/workflows/on-push-to-main-innboks-prod-gcp.yaml
@@ -1,0 +1,25 @@
+name: Deploy innboks-topic i prod-gcp
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - prod-gcp/aapen-brukernotifikasjon-innboks.yaml
+
+jobs:
+  build-and-publish-on-master:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Sjekk ut koden
+        uses: actions/checkout@v2
+
+      - name: 'Deploy-er til min-side i prod-gcp'
+        uses: 'nais/deploy/actions/deploy@v1'
+        env:
+          REF: ${{ github.sha }}
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: prod-gcp
+          RESOURCE: ./prod-gcp/aapen-brukernotifikasjon-innboks.yaml
+          PRINT_PAYLOAD: true

--- a/.github/workflows/on-push-to-main-oppgave-dev-gcp.yaml
+++ b/.github/workflows/on-push-to-main-oppgave-dev-gcp.yaml
@@ -1,0 +1,25 @@
+name: Deploy oppgave-topic i dev-gcp
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - dev-gcp/aapen-brukernotifikasjon-oppgave.yaml
+
+jobs:
+  build-and-publish-on-master:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Sjekk ut koden
+        uses: actions/checkout@v2
+
+      - name: 'Deploy-er til min-side i dev-gcp'
+        uses: 'nais/deploy/actions/deploy@v1'
+        env:
+          REF: ${{ github.sha }}
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: dev-gcp
+          RESOURCE: ./dev-gcp/aapen-brukernotifikasjon-oppgave.yaml
+          PRINT_PAYLOAD: true

--- a/.github/workflows/on-push-to-main-oppgave-prod-gcp.yaml
+++ b/.github/workflows/on-push-to-main-oppgave-prod-gcp.yaml
@@ -1,0 +1,25 @@
+name: Deploy oppgave-topic i prod-gcp
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - prod-gcp/aapen-brukernotifikasjon-oppgave.yaml
+
+jobs:
+  build-and-publish-on-master:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Sjekk ut koden
+        uses: actions/checkout@v2
+
+      - name: 'Deploy-er til min-side i prod-gcp'
+        uses: 'nais/deploy/actions/deploy@v1'
+        env:
+          REF: ${{ github.sha }}
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: prod-gcp
+          RESOURCE: ./prod-gcp/aapen-brukernotifikasjon-oppgave.yaml
+          PRINT_PAYLOAD: true

--- a/.github/workflows/on-push-to-main-statusoppdatering-dev-gcp.yaml
+++ b/.github/workflows/on-push-to-main-statusoppdatering-dev-gcp.yaml
@@ -1,0 +1,25 @@
+name: Deploy statusoppdatering-topic i dev-gcp
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - dev-gcp/aapen-brukernotifikasjon-statusoppdatering.yaml
+
+jobs:
+  build-and-publish-on-master:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Sjekk ut koden
+        uses: actions/checkout@v2
+
+      - name: 'Deploy-er til min-side i dev-gcp'
+        uses: 'nais/deploy/actions/deploy@v1'
+        env:
+          REF: ${{ github.sha }}
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: dev-gcp
+          RESOURCE: ./dev-gcp/aapen-brukernotifikasjon-statusoppdatering.yaml
+          PRINT_PAYLOAD: true

--- a/.github/workflows/on-push-to-main-statusoppdatering-prod-gcp.yaml
+++ b/.github/workflows/on-push-to-main-statusoppdatering-prod-gcp.yaml
@@ -1,0 +1,25 @@
+name: Deploy statusoppdatering-topic i prod-gcp
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - prod-gcp/aapen-brukernotifikasjon-statusoppdatering.yaml
+
+jobs:
+  build-and-publish-on-master:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Sjekk ut koden
+        uses: actions/checkout@v2
+
+      - name: 'Deploy-er til min-side i prod-gcp'
+        uses: 'nais/deploy/actions/deploy@v1'
+        env:
+          REF: ${{ github.sha }}
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: prod-gcp
+          RESOURCE: ./prod-gcp/aapen-brukernotifikasjon-statusoppdatering.yaml
+          PRINT_PAYLOAD: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.idea/*
+*.iml
+
+# Ignore temp files crated when used from dittnav-meta-repo
+.gradle

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @navikt/dittnav

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# brukernotifikasjon-input-topic-iac
+# brukernotifikasjon-public-topic-iac
+
+Repo med konfigurasjon for hvem som kan produsere og konsumere fra DittNAV sine åpne topics.
+
+## Hvordan kobler jeg meg på interne-dittnav-topics?
+
+**For skrivetilgang**
+
+```
+        - team: myTeam
+          application: myApplication
+          access: write 
+```
+**For lesetilgang**
+
+```
+        - team: myTeam
+          application: myApplication
+          access: read 
+```
+
+# Henvendelser
+
+Spørsmål knyttet til koden eller prosjektet kan rettes mot https://github.com/orgs/navikt/teams/min-side
+
+
+## For NAV-ansatte
+
+Interne henvendelser kan sendes via Slack i kanalen #brukernotifikasjoner.

--- a/dev-gcp/aapen-brukernotifikasjon-beskjed.yaml
+++ b/dev-gcp/aapen-brukernotifikasjon-beskjed.yaml
@@ -1,0 +1,27 @@
+apiVersion: kafka.nais.io/v1
+kind: Topic
+metadata:
+  name: aapen-brukernotifikasjon-beskjed-v1
+  namespace: min-side
+  labels:
+    team: min-side
+  annotations:
+    dcat.data.nav.no/title: "Public input-topic for Dittnav sine beskjed-eventer"
+    dcat.data.nav.no/description: "Produsenter kan sende brukernotifikasjoner til Dittnav"
+    dcat.data.nav.no/keyword: "brukernotifikasjon"
+spec:
+  pool: nav-dev
+  config:
+    cleanupPolicy: delete  # delete, compact
+    minimumInSyncReplicas: 1
+    partitions: 4
+    replication: 3  #  see min/max requirements
+    retentionBytes: -1  # -1 means unlimited
+    retentionHours: 168  # One week
+  acl:
+    - team: min-side
+      application: dittnav-brukernotifikasjonbestiller
+      access: read   # read, write, readwrite
+    - team: personbruker
+      application: dittnav-brukernotifikasjonbestiller
+      access: read

--- a/dev-gcp/aapen-brukernotifikasjon-done.yaml
+++ b/dev-gcp/aapen-brukernotifikasjon-done.yaml
@@ -1,0 +1,27 @@
+apiVersion: kafka.nais.io/v1
+kind: Topic
+metadata:
+  name: aapen-brukernotifikasjon-done-v1
+  namespace: min-side
+  labels:
+    team: min-side
+  annotations:
+    dcat.data.nav.no/title: "Public input-topic for Dittnav sine done-eventer"
+    dcat.data.nav.no/description: "Produsenter kan sende brukernotifikasjoner til Dittnav"
+    dcat.data.nav.no/keyword: "brukernotifikasjon"
+spec:
+  pool: nav-dev
+  config:
+    cleanupPolicy: delete  # delete, compact
+    minimumInSyncReplicas: 1
+    partitions: 4
+    replication: 3  #  see min/max requirements
+    retentionBytes: -1  # -1 means unlimited
+    retentionHours: 168  # One week
+  acl:
+    - team: min-side
+      application: dittnav-brukernotifikasjonbestiller
+      access: read   # read, write, readwrite
+    - team: personbruker
+      application: dittnav-brukernotifikasjonbestiller
+      access: read

--- a/dev-gcp/aapen-brukernotifikasjon-feilrespons.yaml
+++ b/dev-gcp/aapen-brukernotifikasjon-feilrespons.yaml
@@ -1,0 +1,27 @@
+apiVersion: kafka.nais.io/v1
+kind: Topic
+metadata:
+  name: aapen-brukernotifikasjon-feilrespons-v1
+  namespace: min-side
+  labels:
+    team: min-side
+  annotations:
+    dcat.data.nav.no/title: "Public topic for Dittnav sine feilrepons-eventer"
+    dcat.data.nav.no/description: "Produsenter får tilbakemelding etter veil ved sending av andre eventer"
+    dcat.data.nav.no/keyword: "brukernotifikasjon"
+spec:
+  pool: nav-dev
+  config:
+    cleanupPolicy: delete  # delete, compact
+    minimumInSyncReplicas: 1
+    partitions: 4
+    replication: 3  #  see min/max requirements
+    retentionBytes: -1  # -1 means unlimited
+    retentionHours: 168  # One week
+  acl:
+    - team: min-side
+      application: dittnav-brukernotifikasjonbestiller
+      access: write   # read, write, readwrite
+    - team: personbruker
+      application: dittnav-brukernotifikasjonbestiller
+      access: write

--- a/dev-gcp/aapen-brukernotifikasjon-innboks.yaml
+++ b/dev-gcp/aapen-brukernotifikasjon-innboks.yaml
@@ -1,0 +1,27 @@
+apiVersion: kafka.nais.io/v1
+kind: Topic
+metadata:
+  name: aapen-brukernotifikasjon-innboks-v1
+  namespace: min-side
+  labels:
+    team: min-side
+  annotations:
+    dcat.data.nav.no/title: "Public input-topic for Dittnav sine innboks-eventer"
+    dcat.data.nav.no/description: "Produsenter kan sende brukernotifikasjoner til Dittnav"
+    dcat.data.nav.no/keyword: "brukernotifikasjon"
+spec:
+  pool: nav-dev
+  config:
+    cleanupPolicy: delete  # delete, compact
+    minimumInSyncReplicas: 1
+    partitions: 4
+    replication: 3  # see min/max requirements
+    retentionBytes: -1  # -1 means unlimited
+    retentionHours: 168  # One week
+  acl:
+    - team: min-side
+      application: dittnav-brukernotifikasjonbestiller
+      access: read   # read, write, readwrite
+    - team: personbruker
+      application: dittnav-brukernotifikasjonbestiller
+      access: read

--- a/dev-gcp/aapen-brukernotifikasjon-oppgave.yaml
+++ b/dev-gcp/aapen-brukernotifikasjon-oppgave.yaml
@@ -1,0 +1,27 @@
+apiVersion: kafka.nais.io/v1
+kind: Topic
+metadata:
+  name: aapen-brukernotifikasjon-oppgave-v1
+  namespace: min-side
+  labels:
+    team: min-side
+  annotations:
+    dcat.data.nav.no/title: "Public input-topic for Dittnav sine oppgave-eventer"
+    dcat.data.nav.no/description: "Produsenter kan sende brukernotifikasjoner til Dittnav"
+    dcat.data.nav.no/keyword: "brukernotifikasjon"
+spec:
+  pool: nav-dev
+  config:
+    cleanupPolicy: delete  # delete, compact
+    minimumInSyncReplicas: 1
+    partitions: 4
+    replication: 3  #  see min/max requirements
+    retentionBytes: -1  # -1 means unlimited
+    retentionHours: 168  # One week
+  acl:
+    - team: min-side
+      application: dittnav-brukernotifikasjonbestiller
+      access: read   # read, write, readwrite
+    - team: personbruker
+      application: dittnav-brukernotifikasjonbestiller
+      access: read

--- a/dev-gcp/aapen-brukernotifikasjon-statusoppdatering.yaml
+++ b/dev-gcp/aapen-brukernotifikasjon-statusoppdatering.yaml
@@ -1,0 +1,27 @@
+apiVersion: kafka.nais.io/v1
+kind: Topic
+metadata:
+  name: aapen-brukernotifikasjon-statusoppdatering-v1
+  namespace: min-side
+  labels:
+    team: min-side
+  annotations:
+    dcat.data.nav.no/title: "Public input-topic for Dittnav sine statusoppdatering-eventer"
+    dcat.data.nav.no/description: "Produsenter kan sende brukernotifikasjoner til Dittnav"
+    dcat.data.nav.no/keyword: "brukernotifikasjon"
+spec:
+  pool: nav-dev
+  config:
+    cleanupPolicy: delete  # delete, compact
+    minimumInSyncReplicas: 1
+    partitions: 4
+    replication: 3  #  see min/max requirements
+    retentionBytes: -1  # -1 means unlimited
+    retentionHours: 168  # One week
+  acl:
+    - team: min-side
+      application: dittnav-brukernotifikasjonbestiller
+      access: read   # read, write, readwrite
+    - team: personbruker
+      application: dittnav-brukernotifikasjonbestiller
+      access: read

--- a/prod-gcp/aapen-brukernotifikasjon-beskjed.yaml
+++ b/prod-gcp/aapen-brukernotifikasjon-beskjed.yaml
@@ -1,0 +1,24 @@
+apiVersion: kafka.nais.io/v1
+kind: Topic
+metadata:
+  name: aapen-brukernotifikasjon-beskjed-v1
+  namespace: min-side
+  labels:
+    team: min-side
+  annotations:
+    dcat.data.nav.no/title: "Public input-topic for Dittnav sine beskjed-eventer"
+    dcat.data.nav.no/description: "Produsenter kan sende brukernotifikasjoner til Dittnav"
+    dcat.data.nav.no/keyword: "brukernotifikasjon"
+spec:
+  pool: nav-prod
+  config:
+    cleanupPolicy: delete  # delete, compact
+    minimumInSyncReplicas: 1
+    partitions: 4
+    replication: 3  # see min/max requirements
+    retentionBytes: -1  # -1 means unlimited
+    retentionHours: 168  # One week
+  acl:
+    - team: min-side
+      application: dittnav-brukernotifikasjonbestiller
+      access: read   # read, write, readwrite

--- a/prod-gcp/aapen-brukernotifikasjon-done.yaml
+++ b/prod-gcp/aapen-brukernotifikasjon-done.yaml
@@ -1,0 +1,24 @@
+apiVersion: kafka.nais.io/v1
+kind: Topic
+metadata:
+  name: aapen-brukernotifikasjon-done-v1
+  namespace: min-side
+  labels:
+    team: min-side
+  annotations:
+    dcat.data.nav.no/title: "Public input-topic for Dittnav sine done-eventer"
+    dcat.data.nav.no/description: "Produsenter kan sende brukernotifikasjoner til Dittnav"
+    dcat.data.nav.no/keyword: "brukernotifikasjon"
+spec:
+  pool: nav-prod
+  config:
+    cleanupPolicy: delete  # delete, compact
+    minimumInSyncReplicas: 1
+    partitions: 4
+    replication: 3  # see min/max requirements
+    retentionBytes: -1  # -1 means unlimited
+    retentionHours: 168  # One week
+  acl:
+    - team: min-side
+      application: dittnav-brukernotifikasjonbestiller
+      access: read   # read, write, readwrite

--- a/prod-gcp/aapen-brukernotifikasjon-feilrespons.yaml
+++ b/prod-gcp/aapen-brukernotifikasjon-feilrespons.yaml
@@ -1,0 +1,24 @@
+apiVersion: kafka.nais.io/v1
+kind: Topic
+metadata:
+  name: aapen-brukernotifikasjon-feilrespons-v1
+  namespace: min-side
+  labels:
+    team: min-side
+  annotations:
+    dcat.data.nav.no/title: "Public topic for Dittnav sine feilrespons-eventer"
+    dcat.data.nav.no/description: "Produsenter får tilbakemelding etter veil ved sending av andre eventer"
+    dcat.data.nav.no/keyword: "brukernotifikasjon"
+spec:
+  pool: nav-prod
+  config:
+    cleanupPolicy: delete  # delete, compact
+    minimumInSyncReplicas: 1
+    partitions: 4
+    replication: 3  # see min/max requirements
+    retentionBytes: -1  # -1 means unlimited
+    retentionHours: 168  # One week
+  acl:
+    - team: min-side
+      application: dittnav-brukernotifikasjonbestiller
+      access: write  # read, write, readwrite

--- a/prod-gcp/aapen-brukernotifikasjon-innboks.yaml
+++ b/prod-gcp/aapen-brukernotifikasjon-innboks.yaml
@@ -1,0 +1,24 @@
+apiVersion: kafka.nais.io/v1
+kind: Topic
+metadata:
+  name: aapen-brukernotifikasjon-innboks-v1
+  namespace: min-side
+  labels:
+    team: min-side
+  annotations:
+    dcat.data.nav.no/title: "Public input-topic for Dittnav sine innboks-eventer"
+    dcat.data.nav.no/description: "Produsenter kan sende brukernotifikasjoner til Dittnav"
+    dcat.data.nav.no/keyword: "brukernotifikasjon"
+spec:
+  pool: nav-prod
+  config:
+    cleanupPolicy: delete  # delete, compact
+    minimumInSyncReplicas: 1
+    partitions: 4
+    replication: 3  # see min/max requirements
+    retentionBytes: -1  # -1 means unlimited
+    retentionHours: 168  # One week
+  acl:
+    - team: min-side
+      application: dittnav-brukernotifikasjonbestiller
+      access: read   # read, write, readwrite

--- a/prod-gcp/aapen-brukernotifikasjon-oppgave.yaml
+++ b/prod-gcp/aapen-brukernotifikasjon-oppgave.yaml
@@ -1,0 +1,24 @@
+apiVersion: kafka.nais.io/v1
+kind: Topic
+metadata:
+  name: aapen-brukernotifikasjon-oppgave-v1
+  namespace: min-side
+  labels:
+    team: min-side
+  annotations:
+    dcat.data.nav.no/title: "Public input-topic for Dittnav sine oppgave-eventer"
+    dcat.data.nav.no/description: "Produsenter kan sende brukernotifikasjoner til Dittnav"
+    dcat.data.nav.no/keyword: "brukernotifikasjon"
+spec:
+  pool: nav-prod
+  config:
+    cleanupPolicy: delete  # delete, compact
+    minimumInSyncReplicas: 1
+    partitions: 4
+    replication: 3  # see min/max requirements
+    retentionBytes: -1  # -1 means unlimited
+    retentionHours: 168  # One week
+  acl:
+    - team: min-side
+      application: dittnav-brukernotifikasjonbestiller
+      access: read   # read, write, readwrite

--- a/prod-gcp/aapen-brukernotifikasjon-statusoppdatering.yaml
+++ b/prod-gcp/aapen-brukernotifikasjon-statusoppdatering.yaml
@@ -1,0 +1,24 @@
+apiVersion: kafka.nais.io/v1
+kind: Topic
+metadata:
+  name: aapen-brukernotifikasjon-statusoppdatering-v1
+  namespace: min-side
+  labels:
+    team: min-side
+  annotations:
+    dcat.data.nav.no/title: "Public input-topic for Dittnav sine statusoppdatering-eventer"
+    dcat.data.nav.no/description: "Produsenter kan sende brukernotifikasjoner til Dittnav"
+    dcat.data.nav.no/keyword: "brukernotifikasjon"
+spec:
+  pool: nav-prod
+  config:
+    cleanupPolicy: delete  # delete, compact
+    minimumInSyncReplicas: 1
+    partitions: 4
+    replication: 3  # see min/max requirements
+    retentionBytes: -1  # -1 means unlimited
+    retentionHours: 168  # One week
+  acl:
+    - team: min-side
+      application: dittnav-brukernotifikasjonbestiller
+      access: read   # read, write, readwrite


### PR DESCRIPTION
Legger til definisjoner av input topics og feilrespons i åpent repo.

- Repoet er kalt `-public-` i stedet for `-input-` fordi det også holder på feilrespons-topicen. Dette er gjort slik at produsentene har 1 iac-repo å forholde seg til når de vil koble seg på.
- Retention for alle topics definert her er satt til 1 uke. Tar gjerne noen innspill her.
- BnB starter som consumer for alle topics utenom feilrespons, der den er produsent. 