### PR TITLE
Flytte sf-brukernotifikasjon til aiven (dev)

### DIFF
--- a/dev-gcp/aapen-brukernotifikasjon-beskjed.yaml
+++ b/dev-gcp/aapen-brukernotifikasjon-beskjed.yaml
@@ -52,3 +52,7 @@ spec:
     - team: pto
       application: veilarbaktivitet
       access: write
+    - team: teamnks
+      application: sf-brukernotifikasjon
+      access: write
+      

--- a/dev-gcp/aapen-brukernotifikasjon-done.yaml
+++ b/dev-gcp/aapen-brukernotifikasjon-done.yaml
@@ -55,3 +55,6 @@ spec:
     - team: teamsykmelding
       application: syfosmvarsel
       access: write
+    - team: teamnks
+      application: sf-brukernotifikasjon
+      access: write

--- a/dev-gcp/aapen-brukernotifikasjon-innboks.yaml
+++ b/dev-gcp/aapen-brukernotifikasjon-innboks.yaml
@@ -28,3 +28,6 @@ spec:
     - team: min-side
       application: tms-event-test-producer
       access: write
+    - team: teamnks
+      application: sf-brukernotifikasjon
+      access: write

--- a/dev-gcp/aapen-brukernotifikasjon-oppgave.yaml
+++ b/dev-gcp/aapen-brukernotifikasjon-oppgave.yaml
@@ -49,3 +49,6 @@ spec:
     - team: teamsykmelding
       application: syfosmvarsel
       access: write
+    - team: teamnks
+      application: sf-brukernotifikasjon
+      access: write


### PR DESCRIPTION
Tilsvarande srvsfnksbrknot on-prem, trengen appen sf-brukernotifikasjon tillgang i aiven