### PR TITLE
Sf brukernotifikasjon to aiven (prod)

### DIFF
--- a/prod-gcp/aapen-brukernotifikasjon-done.yaml
+++ b/prod-gcp/aapen-brukernotifikasjon-done.yaml
@@ -70,3 +70,6 @@ spec:
     - team: teampam
       application: pam-brukernotifikasjon
       access: write
+    - team: teamnks
+      application: sf-brukernotifikasjon
+      access: write

--- a/prod-gcp/aapen-brukernotifikasjon-innboks.yaml
+++ b/prod-gcp/aapen-brukernotifikasjon-innboks.yaml
@@ -25,3 +25,6 @@ spec:
     - team: min-side
       application: tms-event-test-producer
       access: write
+    - team: teamnks
+      application: sf-brukernotifikasjon
+      access: write


### PR DESCRIPTION
Migration of sf-brukernotifikasjon to use aiven. The app is salesforces proxy to post to brukernotifikasjon kafka 