### PR TITLE
Pdl fullmakt send beskjed

### DIFF
--- a/dev-gcp/aapen-brukernotifikasjon-beskjed.yaml
+++ b/dev-gcp/aapen-brukernotifikasjon-beskjed.yaml
@@ -97,3 +97,6 @@ spec:
     - team: team-researchops
       application: innbyggerpanelet-backend
       access: write
+    - team: pdl
+      application: pdl-fullmakt
+      access: write

--- a/prod-gcp/aapen-brukernotifikasjon-beskjed.yaml
+++ b/prod-gcp/aapen-brukernotifikasjon-beskjed.yaml
@@ -76,3 +76,7 @@ spec:
     - team: helsearbeidsgiver
       application: fritakagp
       access: write
+    - team: pdl
+      application: pdl-fullmakt
+      access: write
+

--- a/prod-gcp/aapen-brukernotifikasjon-beskjed.yaml
+++ b/prod-gcp/aapen-brukernotifikasjon-beskjed.yaml
@@ -79,4 +79,3 @@ spec:
     - team: pdl
       application: pdl-fullmakt
       access: write
-


### PR DESCRIPTION
Bestiller tilgang til beskjed topic for pdl-fullmakt appen. I vårt tilfellet trenger vi foreløpig ikke tilgang til done topicet. Appen det er snakk om kjører i fss og vi lurer dermed på om vi trenger å foreta oss noen spesielle tilpasninger på grunn av dette? 