### PR TITLE
Legge til tilleggstønader som produsent

### DIFF
--- a/dev-gcp/aapen-brukernotifikasjon-beskjed.yaml
+++ b/dev-gcp/aapen-brukernotifikasjon-beskjed.yaml
@@ -118,4 +118,6 @@ spec:
     - team: bidrag
       application: bidrag-reisekostnad-api
       access: write
-
+    - team: tilleggstonader
+      application: tilleggsstonader-soknad-api
+      access: write


### PR DESCRIPTION
Team tilleggstønad trenger å kunne sende notifikasjon til bruker.